### PR TITLE
fix: update homepage title and hide license/footer, custom 404

### DIFF
--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=./quartz/plugins/quartz-plugins.schema.json
 configuration:
-  pageTitle: "Tom Plant"
+  pageTitle: "Tom's Garden"
   pageTitleSuffix: " | Tom Plant"
   enableSPA: true
   enablePopovers: true

--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -143,6 +143,7 @@ plugins:
     layout:
       position: right
       priority: 30
+      condition: not-index
   - source: github:quartz-community/search
     enabled: true
     layout:

--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -9,23 +9,15 @@ const NotFound: QuartzComponent = ({ cfg, ctx }: QuartzComponentProps) => {
     <article class="popover-hint">
       <h1>404</h1>
       <p class="error-poem">
-        Once upon a midnight dreary,
+        Once upon a midnight dreary, while I web surfed, weak and weary,
         <br />
-        While I web surfed, weak and weary,
+        For many a quaint and curious page of forgotten lore—
         <br />
-        For pages long forgotten yore.
+        When I clicked my fav'rite href, suddenly there came a warning,
         <br />
-        When I clicked my fav'rite href,
+        and my heart was filled with mourning, mourning for my dear amour,
         <br />
-        Suddenly there came a warning,
-        <br />
-        and my heard was filled with mourning,
-        <br />
-        Mourning for my dear amour,
-        <br />
-        "Tis not possible!", I muttered,
-        <br />
-        "Give thine pages, I emplore!"
+        "Tis not possible!", I muttered, "Give thine pages, I implore!"
         <br />
         Quoth the server, <strong>404</strong>.
       </p>

--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -8,7 +8,27 @@ const NotFound: QuartzComponent = ({ cfg, ctx }: QuartzComponentProps) => {
   return (
     <article class="popover-hint">
       <h1>404</h1>
-      <p>{i18n(cfg.locale).pages.error.notFound}</p>
+      <p class="error-poem">
+        Once upon a midnight dreary,
+        <br />
+        While I web surfed, weak and weary,
+        <br />
+        For pages long forgotten yore.
+        <br />
+        When I clicked my fav'rite href,
+        <br />
+        Suddenly there came a warning,
+        <br />
+        and my heard was filled with mourning,
+        <br />
+        Mourning for my dear amour,
+        <br />
+        "Tis not possible!", I muttered,
+        <br />
+        "Give thine pages, I emplore!"
+        <br />
+        Quoth the server, <strong>404</strong>.
+      </p>
       <a href={baseDir}>{i18n(cfg.locale).pages.error.home}</a>
       <script
         dangerouslySetInnerHTML={{

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -113,8 +113,9 @@ body[data-slug="index"] footer {
 // ----------------------------------------------------------------------------
 // More breathing room between the body text and the sidebars (desktop).
 // Widening the sidebars' inner padding keeps the header and article aligned.
-// On the right, the TOC stays pinned to the top while the backlinks and graph
-// are pushed to the bottom (margin-top: auto absorbs the free space above them).
+// On the right, when a TOC is present it stays pinned to the top while the
+// backlinks and graph are pushed to the bottom (margin-top: auto absorbs the
+// free space above them); with no TOC they sit at the top instead.
 // ----------------------------------------------------------------------------
 @media all and ($desktop) {
   .page > #quartz-body .sidebar.left {
@@ -125,15 +126,19 @@ body[data-slug="index"] footer {
     padding-left: 3.5rem;
   }
 
-  // Pin the backlinks + graph cluster to the bottom of the right sidebar while
-  // the TOC stays at the top. The auto top-margin lands on whichever of the two
-  // comes first (backlinks is absent on pages with no inbound links); when both
-  // are present, the graph drops back to the normal gap so they stay together.
-  .page > #quartz-body .sidebar.right > .backlinks,
-  .page > #quartz-body .sidebar.right > .graph {
+  // Pin the backlinks + graph cluster to the bottom of the right sidebar, but
+  // only when a table of contents is present to anchor against the top (the TOC
+  // is desktop-only, so :has(.toc) also scopes this to pages that actually have
+  // one). Without a TOC there's nothing above them, so they sit at the top in
+  // normal flow instead of floating at the bottom. The auto top-margin lands on
+  // whichever of the two comes first (backlinks is absent on pages with no
+  // inbound links); when both are present, the graph drops back to the normal
+  // gap so they stay together.
+  .page > #quartz-body .sidebar.right:has(.toc) > .backlinks,
+  .page > #quartz-body .sidebar.right:has(.toc) > .graph {
     margin-top: auto;
   }
-  .page > #quartz-body .sidebar.right > .backlinks ~ .graph {
+  .page > #quartz-body .sidebar.right:has(.toc) > .backlinks ~ .graph {
     margin-top: 0;
   }
 }

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -22,6 +22,14 @@ footer {
   margin-bottom: 1rem;
 }
 
+// Hide the site footer on the homepage. The footer is a structural layout slot
+// (not a right/left/beforeBody component), so the `condition: not-index` config
+// option doesn't reach it — hide it via CSS instead. The graph is hidden through
+// that condition in quartz.config.yaml.
+body[data-slug="index"] footer {
+  display: none;
+}
+
 // ----------------------------------------------------------------------------
 // Graph: paint the container and its (transparent) canvas with the theme
 // background so the graph doesn't flash white while the PIXI canvas


### PR DESCRIPTION
## Description

This PR makes two updates to improve the homepage presentation:

1. **Hide footer on homepage**: Added CSS rule to hide the site footer when viewing the index page. Since the footer is a structural layout slot (not a component with conditional rendering support), CSS is used to hide it via `body[data-slug="index"] footer { display: none; }`. This complements the existing graph hiding via the `condition: not-index` config option.

2. **Update site title**: Changed the page title from "Tom Plant" to "Tom's Garden" to better reflect the site's branding.

3. **Hide graph on homepage**: Added `condition: not-index` to the graph plugin configuration to prevent it from displaying on the index page.

## Changes

- `quartz/styles/custom.scss`: Added CSS rule to hide footer on homepage with explanatory comment
- `quartz.config.yaml`: 
  - Updated `pageTitle` from "Tom Plant" to "Tom's Garden"
  - Added `condition: not-index` to graph plugin layout configuration

## Test Plan

N/A - Configuration and styling changes. Verify visually that the footer and graph are not displayed on the homepage while remaining visible on other pages.

https://claude.ai/code/session_01TarVk14khqV7wysMsQXFyw