### PR TITLE
fix: reorder date priority to prefer frontmatter over git

### DIFF
--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -46,8 +46,8 @@ plugins:
     options:
       defaultDateType: modified
       priority:
-        - git
         - frontmatter
+        - git
         - filesystem
     order: 10
   - source: github:quartz-community/syntax-highlighting


### PR DESCRIPTION
## Description

This change reorders the date priority configuration in `quartz.config.yaml` to prioritize frontmatter-defined dates over git commit dates when determining a page's modification date.

### Changes

- Moved `frontmatter` before `git` in the `priority` array under the `lastmod` plugin options
- This ensures that explicit dates defined in page frontmatter take precedence over automatically detected git commit dates

### Rationale

By prioritizing frontmatter dates, content creators have explicit control over how modification dates are displayed, which is useful when:
- A page's content is significantly updated but the git history doesn't reflect the actual modification
- Manual date overrides are needed for specific pages
- Frontmatter provides more accurate semantic information than git history

The priority chain now reads: `frontmatter` → `git` → `filesystem`, giving users the most control while maintaining fallback options.

### Test Plan

N/A - Configuration change with no automated tests required. The change can be verified by checking that pages with frontmatter dates use those dates, while pages without frontmatter dates fall back to git history.

https://claude.ai/code/session_01KSBt4s334QCU8uFBzsz8CT