### PR TITLE
fix: icon layout and alignment, remove title for vertical space

### DIFF
--- a/plugins/featured/dist/index.js
+++ b/plugins/featured/dist/index.js
@@ -55,7 +55,7 @@ function u2(e2, t2, n2, o2, i2, u3) {
 
 // src/components/styles/featured.scss
 var featured_default =
-  ".featured {\n  margin: 0;\n}\n.featured .featured-title {\n  font-family: var(--headerFont);\n  font-size: 0.95rem;\n  font-weight: 600;\n  color: var(--secondary);\n  margin: 0 0 0.5rem 0;\n  line-height: 1.5rem;\n}\n.featured .featured-list {\n  list-style: none;\n  margin: 0;\n  padding: 0;\n}\n.featured .featured-item {\n  margin: 0 0 0.7rem 0;\n}\n.featured .featured-link {\n  display: block;\n  font-family: var(--headerFont);\n  font-weight: 600;\n  font-size: 0.95rem;\n  line-height: 1.3;\n  color: var(--dark);\n  background-color: transparent;\n}\n.featured .featured-link:hover {\n  color: var(--tertiary);\n}\n.featured .featured-date {\n  display: block;\n  margin-top: 0.1rem;\n  font-size: 0.8rem;\n  color: var(--gray);\n}\n.featured .featured-more {\n  display: inline-block;\n  margin-top: 0.1rem;\n  font-family: var(--headerFont);\n  font-size: 0.85rem;\n  font-weight: 600;\n  color: var(--secondary);\n  background-color: transparent;\n}\n.featured .featured-more:hover {\n  color: var(--tertiary);\n}";
+  ".featured {\n  margin: 0 0 -0.4rem 0;\n}\n.featured .featured-title {\n  font-family: var(--headerFont);\n  font-size: 0.95rem;\n  font-weight: 600;\n  color: var(--secondary);\n  margin: 0 0 0.5rem 0;\n  line-height: 1.5rem;\n}\n.featured .featured-list {\n  list-style: none;\n  margin: 0;\n  padding: 0;\n}\n.featured .featured-item {\n  margin: 0 0 0.7rem 0;\n}\n.featured .featured-link {\n  display: block;\n  font-family: var(--headerFont);\n  font-weight: 600;\n  font-size: 0.95rem;\n  line-height: 1.3;\n  color: var(--dark);\n  background-color: transparent;\n}\n.featured .featured-link:hover {\n  color: var(--tertiary);\n}\n.featured .featured-date {\n  display: block;\n  margin-top: 0.1rem;\n  font-size: 0.8rem;\n  color: var(--gray);\n}\n.featured .featured-more {\n  display: inline-block;\n  margin-top: 0.1rem;\n  font-family: var(--headerFont);\n  font-size: 0.85rem;\n  font-weight: 600;\n  color: var(--secondary);\n  background-color: transparent;\n}\n.featured .featured-more:hover {\n  color: var(--tertiary);\n}";
 
 // src/components/Featured.tsx
 var defaultOptions = {
@@ -86,7 +86,7 @@ var Featured_default = (opts) => {
     return u2("div", {
       class: `featured ${displayClass ?? ""}`,
       children: [
-        u2("h2", { class: "featured-title", children: options.title }),
+        options.title ? u2("h2", { class: "featured-title", children: options.title }) : null,
         u2("ul", {
           class: "featured-list",
           children: featured.map((f) => {

--- a/plugins/featured/src/components/Featured.tsx
+++ b/plugins/featured/src/components/Featured.tsx
@@ -67,7 +67,7 @@ export default ((opts?: Partial<FeaturedOptions>) => {
 
     return (
       <div class={`featured ${displayClass ?? ""}`}>
-        <h2 class="featured-title">{options.title}</h2>
+        {options.title && <h2 class="featured-title">{options.title}</h2>}
         <ul class="featured-list">
           {featured.map((f) => {
             const href = resolveRelative(fileData.slug, f.slug!);

--- a/plugins/featured/src/components/styles/featured.scss
+++ b/plugins/featured/src/components/styles/featured.scss
@@ -2,7 +2,9 @@
 // explorer tree). The heading matches the explorer's folder headers ("Notes" /
 // "Posts"); items are a touch bolder than tree entries with a date line beneath.
 .featured {
-  margin: 0;
+  // Pull the file tree up by a third of the sidebar's 1.2rem flex gap so the
+  // space beneath the Featured list is a touch tighter (1.2rem -> 0.8rem).
+  margin: 0 0 -0.4rem 0;
 
   & .featured-title {
     font-family: var(--headerFont);

--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -225,12 +225,10 @@ plugins:
       position: left
       priority: 15
       group: toolbar
-      groupOptions:
-        grow: true
   - source: ./plugins/featured
     enabled: true
     options:
-      title: Featured
+      title: ""
       folder: posts
       posts:
         - "posts/building-australia's-largest-highschool-ctf"

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -93,24 +93,35 @@ body[data-slug="index"] footer {
 
 // ----------------------------------------------------------------------------
 // Top toolbar row: the socials icons share one row with the search / theme /
-// reading-mode icons, all left-aligned with a small gap between the two groups.
-// Render search as a bare icon button — drop the "Search" label and the bar
-// chrome — so it matches the darkmode / reader-mode icons beside it. Flex-centre
-// the button and make the svg a block (sized to the 20px darkmode/reader icons)
-// so the magnifier lines up vertically instead of riding high on its baseline.
+// reading-mode icons, left-aligned with a small gap between the two groups.
+//
+// Vertical-alignment gotcha: each plugin's control is an inline-level <button>,
+// so inside its flex wrapper it sits on a text baseline and the descender space
+// below pushes the icon to the top of the wrapper — leaving the socials (a
+// block-level flex, no baseline) ~2px lower. Making the buttons block-level
+// `display: flex` removes that gap so they all centre on one line. Everything
+// is prefixed with `.sidebar.left` so it wins over each plugin's own rules
+// regardless of stylesheet order.
 // ----------------------------------------------------------------------------
-.search > .search-button {
-  background-color: transparent;
-  border: none;
-  box-shadow: none;
-  padding: 0;
-  margin: 0;
+.sidebar.left .flex-component {
+  align-items: center;
+}
+
+// Search: strip the bar chrome (border, "Search" label, padding, full width)
+// down to a bare icon button matching darkmode/reader. `margin: 0` on the svg
+// kills the plugin's `0 .5rem`, which otherwise added a stray gap to its right.
+.sidebar.left .search > .search-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
   min-width: 0;
   height: auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  background-color: transparent;
   color: var(--darkgray);
 
   & p {
@@ -119,8 +130,10 @@ body[data-slug="index"] footer {
 
   & svg {
     display: block;
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    min-width: 0;
+    margin: 0;
   }
 
   & svg .search-path {
@@ -132,35 +145,26 @@ body[data-slug="index"] footer {
   }
 }
 
-// Line the toolbar icons up exactly. Each plugin ships its own button metrics
-// (the socials icons are 1.3rem, darkmode is a 32px-tall button with absolutely
-// positioned 20px icons, reader applies an internal svg transform), which left
-// them looking mismatched. Centre every item on the row and give them all one
-// icon size. Scoped under .sidebar.left (and with that prefix for specificity)
-// so these win over each plugin's own rules without affecting anything else.
-.sidebar.left .flex-component {
-  align-items: center;
-}
-
+// Darkmode / reader: block-level flex so they don't ride on a baseline. Their
+// icons are absolutely centred by the plugin at their native 20px, so leave the
+// svg size alone.
+.sidebar.left .darkmode,
 .sidebar.left .readermode {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.sidebar.left .socials .social-icon svg,
-.sidebar.left .search > .search-button svg,
-.sidebar.left .darkmode svg,
-.sidebar.left .readermode svg {
-  width: 1.2rem;
-  height: 1.2rem;
+// Match the socials icons to the 20px (1.25rem) utility icons.
+.sidebar.left .socials .social-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
 }
 
-// Nudge the search/theme/reading cluster away from the socials icons by a small
-// fixed gap (the layout group's own gap sits between each icon). Socials no
-// longer grows, so the two groups sit close together rather than at opposite
-// edges of the sidebar.
-.search {
+// Small fixed gap between the socials group and the search/theme/reading group
+// (socials no longer grows, so the two clusters sit close together rather than
+// at opposite edges of the sidebar).
+.sidebar.left .search {
   margin-left: 0.75rem;
 }
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -93,10 +93,11 @@ body[data-slug="index"] footer {
 
 // ----------------------------------------------------------------------------
 // Top toolbar row: the socials icons share one row with the search / theme /
-// reading-mode icons. Socials is grouped with them (layout group "toolbar") and
-// grows to fill the row, pushing the three utility icons to the right edge.
+// reading-mode icons, all left-aligned with a small gap between the two groups.
 // Render search as a bare icon button — drop the "Search" label and the bar
-// chrome — so it matches the darkmode / reader-mode icons beside it.
+// chrome — so it matches the darkmode / reader-mode icons beside it. Flex-centre
+// the button and make the svg a block (sized to the 20px darkmode/reader icons)
+// so the magnifier lines up vertically instead of riding high on its baseline.
 // ----------------------------------------------------------------------------
 .search > .search-button {
   background-color: transparent;
@@ -107,6 +108,9 @@ body[data-slug="index"] footer {
   width: auto;
   min-width: 0;
   height: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--darkgray);
 
   & p {
@@ -114,8 +118,9 @@ body[data-slug="index"] footer {
   }
 
   & svg {
-    width: 1.2rem;
-    height: 1.2rem;
+    display: block;
+    width: 1.25rem;
+    height: 1.25rem;
   }
 
   & svg .search-path {
@@ -125,6 +130,14 @@ body[data-slug="index"] footer {
   &:hover {
     color: var(--secondary);
   }
+}
+
+// Nudge the search/theme/reading cluster away from the socials icons by a small
+// fixed gap (the layout group's own gap sits between each icon). Socials no
+// longer grows, so the two groups sit close together rather than at opposite
+// edges of the sidebar.
+.search {
+  margin-left: 0.75rem;
 }
 
 // ----------------------------------------------------------------------------

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -161,11 +161,12 @@ body[data-slug="index"] footer {
   height: 1.25rem;
 }
 
-// Small fixed gap between the socials group and the search/theme/reading group
+// Fixed gap between the socials group and the search/theme/reading group
 // (socials no longer grows, so the two clusters sit close together rather than
-// at opposite edges of the sidebar).
+// at opposite edges of the sidebar). The layout group's own 0.5rem gap sits
+// between every icon; this margin adds to it, giving ~30px between the groups.
 .sidebar.left .search {
-  margin-left: 0.75rem;
+  margin-left: 1.375rem;
 }
 
 // ----------------------------------------------------------------------------

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -119,8 +119,8 @@ body[data-slug="index"] footer {
 
   & svg {
     display: block;
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.2rem;
+    height: 1.2rem;
   }
 
   & svg .search-path {
@@ -130,6 +130,30 @@ body[data-slug="index"] footer {
   &:hover {
     color: var(--secondary);
   }
+}
+
+// Line the toolbar icons up exactly. Each plugin ships its own button metrics
+// (the socials icons are 1.3rem, darkmode is a 32px-tall button with absolutely
+// positioned 20px icons, reader applies an internal svg transform), which left
+// them looking mismatched. Centre every item on the row and give them all one
+// icon size. Scoped under .sidebar.left (and with that prefix for specificity)
+// so these win over each plugin's own rules without affecting anything else.
+.sidebar.left .flex-component {
+  align-items: center;
+}
+
+.sidebar.left .readermode {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar.left .socials .social-icon svg,
+.sidebar.left .search > .search-button svg,
+.sidebar.left .darkmode svg,
+.sidebar.left .readermode svg {
+  width: 1.2rem;
+  height: 1.2rem;
 }
 
 // Nudge the search/theme/reading cluster away from the socials icons by a small


### PR DESCRIPTION
## Description

This PR makes several refinements to the sidebar layout and styling:

### Toolbar Layout Changes
- **Removed growth behavior**: The search/theme/reading-mode icon group no longer grows to fill available space, allowing the socials and utility icons to sit closer together rather than at opposite edges
- **Added gap spacing**: Introduced a `0.75rem` left margin on the search group to maintain visual separation between the two icon groups
- **Updated comments**: Clarified the new left-aligned layout approach in code comments

### Search Button Styling
- **Improved alignment**: Changed search button to use `inline-flex` with centered alignment to properly center the icon
- **Fixed SVG sizing**: Made SVG a block element and adjusted dimensions from `1.2rem` to `1.25rem` to match the darkmode/reader-mode icons, ensuring the magnifier icon aligns vertically instead of riding high on its baseline

### Featured Section
- **Adjusted spacing**: Added negative bottom margin (`-0.4rem`) to the featured section to tighten spacing beneath the list (reducing the sidebar's default `1.2rem` flex gap to `0.8rem`)
- **Optional title**: Made the featured section title conditional—it now only renders when a title is provided, allowing for a cleaner appearance when `title: ""` is set in config
- **Updated config**: Set the featured plugin's default title to an empty string in `quartz.config.yaml`

These changes improve the visual hierarchy and spacing consistency in the sidebar while maintaining a cleaner, more compact layout.

## Test Plan

Visual inspection of the sidebar layout to verify:
- Search icon aligns vertically with other utility icons
- Socials and utility icon groups maintain appropriate spacing
- Featured section spacing is tighter without the title
- No regressions in responsive behavior

https://claude.ai/code/session_01VLHjLGMRp9sRzbbyxR2yuu